### PR TITLE
[Update] #62 投稿にもメダルアイコンが表示されるよう修正

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -8,9 +8,15 @@
     <div class="flex justify-between items-center mb-4">
       <div class="inline-flex items-center flex-grow">
         <%= image_tag diary.user.avatar_image.url, class: 'w-10 h-10 rounded-full flex-shrink-0 object-cover object-center border border-zinc-200' %>
-        <span class="flex-grow flex flex-col pl-3">
+        <span class="flex-none flex flex-col pl-3">
           <span class="title-font font-medium"><%= diary.user.name %></span>
         </span>
+        <% color = diary.user.decorate.medal_color %>
+        <% unless color.nil? %>
+          <div class="flex-grow ml-3">
+            <i class="fa-solid fa-medal fa-xl" style="color: <%= color %>"></i>
+          </div>
+        <% end %>
       </div>
 
       <p class="text-xs border rounded-full px-2.5 py-1 border-terracotta/70 text-gray-500"><%= diary.allow_publication ? '公開' : '非公開' %></p>


### PR DESCRIPTION
## issueへのリンク

https://github.com/meimei-kr/illumi-diary/issues/62

## やったこと

自分にしか見えないヘッダーのアバター横だけではなく、他の人にも見えるように投稿欄のアバター横にもメダルアイコンを表示するように修正しました。

## やらないこと

なし

## できるようになること（ユーザ目線）

メダル会員になった場合、ヘッダーに加えて、自分の投稿した日記にもメダルが表示されるようになります。

## できなくなること（ユーザ目線）

なし

## 動作確認

以下の手順で動作確認を行いました。
1. メダル会員ではないユーザー１でログインして日記を投稿
2. メダル会員であるユーザー２でログインして日記を投稿
3. ユーザー１の投稿にはメダルは表示されておらず、ユーザー２の投稿にはメダルが表示されていることを確認
[![Image from Gyazo](https://i.gyazo.com/633edd65dfcde480372543e5330ba67a.png)](https://gyazo.com/633edd65dfcde480372543e5330ba67a)

## その他

なし
