### PR TITLE
[Fix] iPhoneでactive擬似クラスが動作しない問題を修正

### DIFF
--- a/app/javascript/clap.js
+++ b/app/javascript/clap.js
@@ -1,11 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
-  var link = document.querySelector(".clap-link");
+  var links = document.querySelectorAll(".clap-link");
 
-  link.addEventListener("touchstart", function () {
-    this.classList.add("active");
-  });
+  links.forEach(function (link) {
+    link.addEventListener("touchstart", function () {
+      this.classList.add("active");
+    });
 
-  link.addEventListener("touchend", function () {
-    this.classList.remove("active");
+    link.addEventListener("touchend", function () {
+      this.classList.remove("active");
+    });
   });
 });


### PR DESCRIPTION
issueへのリンク
https://github.com/meimei-kr/illumi-diary/issues/17

やったこと
iPhoneでactive擬似クラスが動作しない問題を修正しました。

やらないこと
なし

できるようになること（ユーザ目線）
Clapボタンを押下した時のリングエフェクトがiPhoneでも動作するようになり、ボタンを押している感覚を提供できます。

できなくなること（ユーザ目線）
なし

動作確認

その他