### PR TITLE
[Fix] メダル獲得ロジックの修正

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -95,14 +95,15 @@ class DiariesController < ApplicationController
   end
 
   # メダル付与対象の日記記入継続日数か判定して、該当すればユーザーのランクを更新
+  # すでにメダルを獲得済みの場合があるため、１つ下のランクから上がる時だけ実行されるようにif文を記載
   def check_win_medal
     case current_user.continuous_writing_days
     when Medal::BRONZE
-      current_user.bronze!
+      current_user.bronze! if current_user.general?
     when Medal::SILVER
-      current_user.silver!
+      current_user.silver! if current_user.bronze?
     when Medal::GOLD
-      current_user.gold!
+      current_user.gold! if current_user.silver?
     end
   end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -3,6 +3,8 @@
 class UserDecorator < ApplicationDecorator
   delegate_all
 
+  # ビューから呼ばれるメソッド
+  # このメソッドが呼ばれるときには会員ランク更新済みなので、controllerのcheck_win_medalメソッドのようにif文はつけない
   def medal_to_give
     case object.continuous_writing_days
     when Medal::BRONZE

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,8 +41,8 @@ class User < ApplicationRecord
     (Time.zone.today - 99..Time.zone.today).reverse_each do |date|
       start_of_day = date.beginning_of_day
       end_of_day = date.end_of_day
-      diaries_of_today = diaries.where(created_at: start_of_day..end_of_day)
-      break if diaries_of_today.blank?
+      diaries_until_today = diaries.where(created_at: start_of_day..end_of_day)
+      break if diaries_until_today.blank?
 
       days += 1
     end


### PR DESCRIPTION
Close #77

## issueへのリンク
#77

## やったこと
メダル獲得ロジックを修正しました。
【修正前】例）3日連続日記を書き銅メダル獲得後、1日空いて、また3日間日記を書くと、再度銅メダル獲得のメッセージが出ていた
【修正後】例）3日連続日記を書き銅メダル獲得後、1日空いて、また3日間日記を書くと通常のメッセージが出る

## やらないこと
なし

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
なし

## 動作確認
- 前述の銅メダル獲得の例を試し、修正されていることを確認しました。
- 日記を追加していき、銀メダル、金メダル獲得時に、会員のステータス、表示されるメダル、メッセージが正しいことを確認しました。

## その他
なし
