### PR TITLE
[Fix] #17 長いユーザー名が設定された場合の表示を修正

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,29 +1,33 @@
 <div id="<%= dom_id diary %>" class="md:px-8 px-6 md:py-8 py-6 flex flex-wrap md:flex-nowrap md:flex-row flex-col bg-white rounded-lg mb-2">
-<div class="flex flex-row max-w-full">
-  <div class="w-12 flex-shrink-0 flex flex-col text-center leading-none mr-1">
-    <span class="md:text-sm text-xs pb-2 mb-2 border-b-2 border-gray-400/30"><%= diary.created_at.to_s[5,2] %></span>
-    <span class="font-medium md:text-xl text-lg title-font leading-none"><%= diary.created_at.to_s[8,2] %></span>
-  </div>
-  <div class="md:hidden flex flex-1 justify-end items-center mb-4 w-full overflow-hidden">
-    <div class="flex justify-end items-center w-full">
-      <%= image_tag diary.user.avatar_image.url, class: 'w-10 h-10 rounded-full flex-shrink-0 object-cover object-center border border-zinc-200' %>
-      <span class="flex-1 flex flex-col sm:pl-3 pl-1 max-w-[50%]">
-        <span class="title-font font-medium sm:text-base text-sm truncate"><%= diary.user.name %></span>
-      </span>
-      <% color = diary.user.decorate.medal_color %>
-      <% unless color.nil? %>
-        <div class="ml-3">
-          <i class="fa-solid fa-medal fa-xl" style="color: <%= color %>"></i>
-        </div>
-      <% end %>
+
+  <div class="flex flex-row max-w-full">
+    <div class="w-12 flex-none flex flex-col text-center leading-none mr-1">
+      <span class="md:text-sm text-xs pb-2 mb-2 border-b-2 border-gray-400/30"><%= diary.created_at.to_s[5,2] %></span>
+      <span class="font-medium md:text-xl text-lg title-font leading-none"><%= diary.created_at.to_s[8,2] %></span>
     </div>
+    <!-- mdブレイクポイントより小さい場合のアバター表示 -->
+    <div class="md:hidden flex flex-1 justify-end items-center mb-4 w-full overflow-hidden">
+      <div class="flex justify-end items-center w-full">
+        <div class="flex flex-1 justify-end">
+          <%= image_tag diary.user.avatar_image.url, class: 'w-10 h-10 rounded-full flex-shrink-0 object-cover object-center border border-zinc-200' %>
+        </div>
+        <div class="sm:pl-3 pl-1 title-font font-medium sm:text-base text-sm truncate max-w-[50%]">
+          <%= diary.user.name %>
+        </div>
+        <% color = diary.user.decorate.medal_color %>
+        <% unless color.nil? %>
+          <div class="ml-3">
+            <i class="fa-solid fa-medal fa-xl" style="color: <%= color %>"></i>
+          </div>
+        <% end %>
+      </div>
 
-    <p class="flex-none text-xs border rounded-full px-2.5 py-1 ml-2 border-terracotta/70 text-gray-500 w-12"><%= diary.allow_publication ? '公開' : '非公開' %></p>
+      <p class="flex-none text-xs border rounded-full px-2.5 py-1 ml-2 border-terracotta/70 text-gray-500 max-w-[56px]"><%= diary.allow_publication ? '公開' : '非公開' %></p>
+    </div>
   </div>
-</div>
-
 
   <div class="flex-grow md:pl-6 pl-0 md:mt-0 mt-4">
+    <!-- mdブレイクポイントより大きい場合のアバター表示 -->
     <div class="md:flex hidden justify-between items-center mb-4">
       <div class="inline-flex items-center flex-grow">
         <%= image_tag diary.user.avatar_image.url, class: 'w-10 h-10 rounded-full flex-shrink-0 object-cover object-center border border-zinc-200' %>


### PR DESCRIPTION
## issueへのリンク
#17

## やったこと
長いユーザー名が設定された場合に、モバイルサイズだと表示が崩れる問題を修正しました。
加えて、前回の修正では、短いユーザー名のときにレイアウトが崩れていたため、適切な位置に表示されるよう修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
モバイル端末でもユーザー名の崩れなく表示させることができます。

## できなくなること（ユーザ目線）
なし

## 動作確認
モバイルサイズ、PCでユーザー名表示が崩れていないことを確認しました。
### モバイル
|[![Image from Gyazo](https://i.gyazo.com/4aeb4115af1a837d42ccf0b9276c3737.png)](https://gyazo.com/4aeb4115af1a837d42ccf0b9276c3737)|[![Image from Gyazo](https://i.gyazo.com/8086455908f6819bf1ce846810f287d9.png)](https://gyazo.com/8086455908f6819bf1ce846810f287d9)
|-|-|

### PC
|[![Image from Gyazo](https://i.gyazo.com/323a61f14e2e8459cce0f22b73da2c96.png)](https://gyazo.com/323a61f14e2e8459cce0f22b73da2c96)|[![Image from Gyazo](https://i.gyazo.com/176d0e4df993ccd58618079c1b6220ba.png)](https://gyazo.com/176d0e4df993ccd58618079c1b6220ba)|
|-|-|

## その他
なし
