### PR TITLE
[Fix] #17 長いユーザー名が設定された場合の表示を修正

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -6,14 +6,14 @@
       <span class="font-medium md:text-xl text-lg title-font leading-none"><%= diary.created_at.to_s[8,2] %></span>
     </div>
     <!-- mdブレイクポイントより小さい場合のアバター表示 -->
+    <div class="md:hidden flex flex-none mr-1">
+      <%= image_tag diary.user.avatar_image.url, class: 'w-10 h-10 rounded-full flex-shrink-0 object-cover object-center border border-zinc-200' %>
+    </div>
     <div class="md:hidden flex flex-1 justify-end items-center mb-4 w-full overflow-hidden">
-      <div class="flex justify-end items-center w-full">
-        <div class="flex flex-1 justify-end">
-          <%= image_tag diary.user.avatar_image.url, class: 'w-10 h-10 rounded-full flex-shrink-0 object-cover object-center border border-zinc-200' %>
-        </div>
-        <div class="sm:pl-3 pl-1 title-font font-medium sm:text-base text-sm truncate max-w-[50%]">
-          <%= diary.user.name %>
-        </div>
+      <div class="sm:pl-3 pl-1 title-font font-medium sm:text-base text-sm truncate w-full">
+        <%= diary.user.name %>
+      </div>
+      <div class="flex flex-none justify-end items-center w-fit">
         <% color = diary.user.decorate.medal_color %>
         <% unless color.nil? %>
           <div class="ml-3">


### PR DESCRIPTION
## issueへのリンク
#17

## やったこと
長いユーザー名が設定された場合に、モバイルサイズだと表示が崩れる問題を修正しました。
加えて、前回の修正では、モバイル実機確認時にアバターが切れて表示されていたため、修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
モバイル端末でもユーザー名の崩れなく表示させることができます。

## できなくなること（ユーザ目線）
なし

## 動作確認
モバイルサイズ、PCでユーザー名表示が崩れていないことを確認しました。
### モバイル
|[![Image from Gyazo](https://i.gyazo.com/a403f0aebe575c0ac231d8d718ec7a4c.png)](https://gyazo.com/a403f0aebe575c0ac231d8d718ec7a4c)|[![Image from Gyazo](https://i.gyazo.com/456ec4afd01093fd8890ba8f038cc034.png)](https://gyazo.com/456ec4afd01093fd8890ba8f038cc034)|
|-|-|

### PC
|[![Image from Gyazo](https://i.gyazo.com/3e559dfe468c55f72e0ff39fe07af412.png)](https://gyazo.com/3e559dfe468c55f72e0ff39fe07af412)|[![Image from Gyazo](https://i.gyazo.com/30302d290c20201788d3493bb525f781.png)](https://gyazo.com/30302d290c20201788d3493bb525f781)|
|-|-|

## その他
なし
