### PR TITLE
[Fix] #17 Androidで非公開表示が崩れていたため修正

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -16,13 +16,13 @@
       <div class="flex flex-none justify-end items-center w-fit">
         <% color = diary.user.decorate.medal_color %>
         <% unless color.nil? %>
-          <div class="ml-3">
+          <div class="sm:ml-3 ml-1">
             <i class="fa-solid fa-medal fa-xl" style="color: <%= color %>"></i>
           </div>
         <% end %>
       </div>
 
-      <p class="flex-none text-xs border rounded-full px-2.5 py-1 ml-2 border-terracotta/70 text-gray-500 max-w-[56px]"><%= diary.allow_publication ? '公開' : '非公開' %></p>
+      <p class="flex-none text-xs border rounded-full sm:px-2.5 px-2 py-1 sm:ml-2 ml-1 border-terracotta/70 text-gray-500 max-w-[60px]"><%= diary.allow_publication ? '公開' : '非公開' %></p>
     </div>
   </div>
 


### PR DESCRIPTION
## issueへのリンク
#17

## やったこと
Androidで非公開表示が崩れていたため修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
非公開表示の崩れなく表示させることができます。

## できなくなること（ユーザ目線）
なし

## 動作確認

## その他
なし