### PR TITLE
[Add] #96 メタタグ設定の追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,11 +9,13 @@ module ApplicationHelper
   def default_meta_tags
     {
       site: 'illumi-diary',
+      title: 'illumi-diary',
       description: 'illumi-diaryは、その日あったポジティブな出来事を3つ記録するための日記アプリです。',
       keywords: 'ポジティブ,日記,記録,アプリ',
       separator: '|',   #Webサイト名とページタイトルを区切るために使用されるテキスト
       og: {
         site_name: :site,
+        title: :title,
         description: :description,
         type: 'website',
         image: image_url('ogp.webp'),
@@ -21,6 +23,7 @@ module ApplicationHelper
       twitter: {
         card: 'summary_large_image', # 大きな画像付きのサマリーカード
         image: image_url('ogp.webp'),
+        title: :title,
       }
     }
   end


### PR DESCRIPTION
## issueへのリンク
#96

## やったこと
メタタグの設定が正常動作していなかったため、設定を追加しました。

X投稿時の検証サイト（https://cards-dev.twitter.com/validator）でURLを入力した際に、以下のようにtitleに関するエラーが出ていたため、 `title` に関する設定を追加しました。
--
INFO:  Page fetched successfully
INFO:  15 metatags were found
INFO:  twitter:card = summary_large_image tag found
ERROR: Possibly invalid value (if specified) (twitter:title)
ERROR: Possibly invalid value (if specified) (og:title)
ERROR: Possibly invalid value (if specified) (twitter:text:title)


## やらないこと
なし

## できるようになること（ユーザ目線）
適切な説明文や画像が表示されることにより、よりユーザーにどのようなアプリか伝わりやすくなります。

## できなくなること（ユーザ目線）
なし

## 動作確認


## その他
なし
