### PR TITLE
[Add] 所有権確認用HTMLファイルの追加

### DIFF
--- a/public/googleb053b6422e8c3235.html
+++ b/public/googleb053b6422e8c3235.html
@@ -1,0 +1,1 @@
+google-site-verification: googleb053b6422e8c3235.html


### PR DESCRIPTION
## issueへのリンク
#96

## やったこと
検索エンジンにdescriptionで設定した内容が反映されていなかったため、Google Search Consoleで所有権確認用HTMLをダウンロードし、publicフォルダに配備しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
meta-tags gemの設定でdescriptionに記載された内容がブラウザの検索結果に表示され、どのようなアプリか適切に伝わります。

## できなくなること（ユーザ目線）
なし

## 動作確認

## その他
なし