### PR TITLE
[Add] #4 日記作成フォームに文字数カウント機能を追加

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@ import "flowbite/dist/flowbite.turbo.js";
 import "./controllers";
 import "./confetti";
 import "./confirm_deletion";
+import "./count";

--- a/app/javascript/count.js
+++ b/app/javascript/count.js
@@ -1,0 +1,24 @@
+import $ from 'jquery';
+
+$(document).on("turbo:load", function() {
+  console.log("jquery called")
+  const maxCount = 140;
+
+  function updateCount(textArea, textCount) {
+    const count = textArea.val().length;
+    const newCount = maxCount - count;
+    textCount.text(`${newCount} / ${maxCount}`)
+    textCount.css("color", newCount < 0 ? "red" : "#666b74");
+  }
+
+  $(".js-text-area-container").each(function() {
+    const textArea = $(this).find(".js-text");
+    const textCount = $(this).find(".js-text-count");
+
+    // 初期表示時
+    updateCount(textArea, textCount);
+
+    // 入力時
+    textArea.on("input", () => updateCount(textArea, textCount));
+  });
+});

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -49,15 +49,15 @@
       <%= link_to diary_path(diary), data: { turbo: false } do %>
         <div class="leading-relaxed mb-5 overflow-hidden break-all flex flex-row md:text-base text-sm">
           <strong class="mr-2">1.</strong>
-          <%= diary.content1 %>
+          <%= simple_format(diary.content1) %>
         </div>
         <div class="leading-relaxed mb-5 overflow-hidden break-all flex flex-row md:text-base text-sm">
           <strong class="mr-2">2.</strong>
-          <%= diary.content2 %>
+          <%= simple_format(diary.content2) %>
         </div>
         <div class="leading-relaxed mb-5 overflow-hidden break-all flex flex-row md:text-base text-sm">
           <strong class="mr-2">3.</strong>
-          <%= diary.content3 %>
+          <%= simple_format(diary.content3) %>
         </div>
       <% end %>
     </div>

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -1,19 +1,22 @@
 <%= form_with(model: diary, class: "contents") do |form| %>
   <%= render 'shared/error_messages', object: form.object %>
 
-  <div class="my-5">
+  <div class="js-text-area-container my-5">
     <%= form.label :content1 %>
-    <%= form.text_area :content1, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: '140文字以内で入力してください' %>
+    <%= form.text_area :content1, rows: 4, class: "js-text block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: '140文字以内で入力してください' %>
+    <p class="js-text-count text-right"></p>
   </div>
 
-  <div class="my-5">
+  <div class="js-text-area-container my-5">
     <%= form.label :content2 %>
-    <%= form.text_area :content2, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: '140文字以内で入力してください' %>
+    <%= form.text_area :content2, rows: 4, class: "js-text block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: '140文字以内で入力してください' %>
+    <p class="js-text-count text-right"></p>
   </div>
 
-  <div class="my-5">
+  <div class="js-text-area-container my-5">
     <%= form.label :content3 %>
-    <%= form.text_area :content3, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: '140文字以内で入力してください' %>
+    <%= form.text_area :content3, rows: 4, class: "js-text block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: '140文字以内で入力してください' %>
+    <p class="js-text-count text-right"></p>
   </div>
 
   <div class="flex flex-row">

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "esbuild": "^0.19.5",
     "flatpickr": "^4.6.13",
     "flowbite": "^1.8.1",
+    "jquery": "^3.7.1",
     "postcss": "^8.4.30",
     "stimulus-notification": "^2.2.0",
     "tailwindcss": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,6 +528,11 @@ jiti@^1.18.2:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"
   integrity sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==
 
+jquery@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
+  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+
 lilconfig@^2.0.5, lilconfig@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"


### PR DESCRIPTION
Close #4 

## issueへのリンク
#4 

## やったこと
日記作成フォームに文字数カウント機能を追加しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
現在の入力文字数を確認しながら、フォームの入力ができるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
入力最大文字数を超えると、文字数がマイナス表示かつ、赤文字で表示されるようになることを確認しました。

## その他
バリデーションに失敗した際は、JavaScriptが実行されず、文字数表示が消えてしまいます。
入力文字数の表示をつけたことで、バリデーションエラーは発生しづらくなると思われますので、現状このままにしています。
解決方法が見つかり次第対応します。