### PR TITLE
[Add] #4 日記作成フォームの文字数表示方法変更

### DIFF
--- a/app/javascript/count.js
+++ b/app/javascript/count.js
@@ -7,7 +7,7 @@ $(document).on("turbo:load", function() {
   function updateCount(textArea, textCount) {
     const count = textArea.val().length;
     const newCount = maxCount - count;
-    textCount.text(`${newCount} / ${maxCount}`)
+    textCount.text(`残り：${newCount}文字`)
     textCount.css("color", newCount < 0 ? "red" : "#666b74");
   }
 


### PR DESCRIPTION
## issueへのリンク
#4

## やったこと
日記作成フォームの文字数表示方法を変更しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
よりユーザーにわかりやすい表示方法になりました。

## できなくなること（ユーザ目線）
なし

## 動作確認
残りの文字数が表示され、超えると赤文字でマイナス表示が出ることを確認しました。

## その他
なし
